### PR TITLE
Fix triage flowchart image reference.

### DIFF
--- a/src-oncall.md
+++ b/src-oncall.md
@@ -50,7 +50,7 @@ Weekly (ideally at the beginning of your shift):
 
 ## Triage Workflow
 
-![Triage workflow flowchart](images/SRC-oncall-triage-flow.png)
+![Triage workflow flowchart](images/src-oncall-triage-flow.png)
 
 ### HackerOne triage details
 


### PR DESCRIPTION
I think the file name got uppercased in the global search and replace, this sets it to match the file name in the repo.