### PR TITLE
Add official-cve-feed label to new vulnerability announcement issues

### DIFF
--- a/comms-templates/vulnerability-announcement-issue.md
+++ b/comms-templates/vulnerability-announcement-issue.md
@@ -66,5 +66,6 @@ _(optional):_ The issue was fixed and coordinated by $FIXTEAM and $RELEASE_MANAG
 /area security
 /kind bug
 /committee security-response
+/label official-cve-feed
 /sig $RELEVANT_SIGS
 /area $IMPACTED_COMPONENTS


### PR DESCRIPTION
Now that https://github.com/kubernetes/test-infra/pull/23428/ has merged, update the communication template so that future CVE announcements will be labeled already