### PR TITLE
Create a self-referential SECURITY_CONTACTS file to silence the bot.

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,17 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Security Response Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# Yes, this is absurd because this repo is for use by the Security Response
+# Committee, and as a tautology, we know how to contact ourselves. Creating
+# this file avoids the need to special-case our own repos in the bot. 
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+committee-security-response


### PR DESCRIPTION
Fixes #143

It would be nice to move forward with plans to deprecate SECURITY_CONTACTS, in the meantime I'd like the bot to be happy.