### PR TITLE
Add a template for a canned response for non-vulnerability emails to the security@ list.

### DIFF
--- a/comms-templates/non-vuln-response.md
+++ b/comms-templates/non-vuln-response.md
@@ -1,0 +1,11 @@
+Thank you for your message.
+
+It appears this report is neither a vulnerability report nor a security incident. Consider one of these public options instead:
+
+- kubernetes-security-discuss@googlegroups.com
+- open an issue: http://issues.k8s.io/new/choose
+- #kubernetes-security slack channel: http://slack.k8s.io/
+
+Thank you,
+
+The Kubernetes Security Response Committee


### PR DESCRIPTION
We often get messages that are well intentioned, but are better handled in one of our open forums. Adding a canned response should slightly reduce the friction and toil on figuring out how to respond respectfully.