### PR TITLE
Documenting Lessons Learnt from recent CVE announcement

### DIFF
--- a/comms-templates/vulnerability-announcement-email.md
+++ b/comms-templates/vulnerability-announcement-email.md
@@ -7,7 +7,7 @@ issue](vulnerability-announcement-issue.md)._
 
 TO: `kubernetes-announce@googlegroups.com, dev@kubernetes.io, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, distributors-announce@kubernetes.io, kubernetes+announcements@discoursemail.com`
 
-Tip: Make sure you are a member / manager of these groups before sending the email as posting new topics is restricted
+Tip: Make sure you are a member / manager of these groups before sending the email as posting new topics is restricted. Ask your fellow SRC members on how to get yourself added to these groups. 
 to members.
 
 SUBJECT: `[Security Advisory] $CVE: $SUMMARY`

--- a/comms-templates/vulnerability-announcement-email.md
+++ b/comms-templates/vulnerability-announcement-email.md
@@ -7,11 +7,16 @@ issue](vulnerability-announcement-issue.md)._
 
 TO: `kubernetes-announce@googlegroups.com, dev@kubernetes.io, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, distributors-announce@kubernetes.io, kubernetes+announcements@discoursemail.com`
 
+Tip: Make sure you are a member / manager of these groups before sending the email as posting new topics is restricted
+to members.
+
 SUBJECT: `[Security Advisory] $CVE: $SUMMARY`
 
 _A separate email should be sent for `oss-security@lists.openwall.com`, with `[kubernetes]` in the subject:_
 
 TO: `oss-security@lists.openwall.com`
+
+Tip: You can find previous conversations in this mailing list here: https://www.openwall.com/lists/oss-security/
 
 SUBJECT: `[kubernetes] $CVE: $SUMMARY`
 
@@ -54,7 +59,7 @@ _(If fix has side effects)_ **Fix impact:** details of impact.
 
 To upgrade, refer to the documentation: ... ($COMPONENT upgrade documentation)
 
-_For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#upgrading-a-cluster
+_For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/
 
 ### Detection
 

--- a/comms-templates/vulnerability-announcement-issue.md
+++ b/comms-templates/vulnerability-announcement-issue.md
@@ -4,8 +4,8 @@ TITLE: `CVE-####-######: $SUMMARY`
 
 ---
 
-<!-- Copy URL after # as the link text -->
-CVSS Rating: [CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L)
+<!-- Copy URL after # as the link text. Note, this is an example and your URL maybe different than this -->
+CVSS Rating: [CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L)
 
 _Description of vulnerability_
 

--- a/security-release-process.md
+++ b/security-release-process.md
@@ -216,6 +216,8 @@ Communications process:
     [patch release](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md)
     will have the fix details included in the patch release notes. Any public announcement sent for
     these fixes will link to the release notes.
+  - Medium and Low vulnerabilities with public fixes (PRs) can be announced on private
+    distributors list at the same time and as part of the general announcement email.
 
 ## Private Distributors List
 

--- a/security-release-process.md
+++ b/security-release-process.md
@@ -217,7 +217,7 @@ Communications process:
     will have the fix details included in the patch release notes. Any public announcement sent for
     these fixes will link to the release notes.
   - Medium and Low vulnerabilities with public fixes (PRs) can be announced on private
-    distributors list at the same time and as part of the general announcement email.
+    distributors list at the same time as the general announcement email.
 
 ## Private Distributors List
 

--- a/src-onboarding-offboarding.md
+++ b/src-onboarding-offboarding.md
@@ -320,7 +320,7 @@ The following checklist can be pasted into an onboarding issue to track all the 
   - [ ] [Security Discuss](https://groups.google.com/forum/#!forum/kubernetes-security-discuss) - owner
   - [ ] [Security Announce](https://groups.google.com/forum/#!forum/kubernetes-security-announce) - owner
   - [ ] [Kubernetes Announce](https://groups.google.com/forum/#!forum/kubernetes-announce) - manager
-  - [ ] [Kubernetes Dev](https://groups.google.com/forum/#!forum/kubernetes-dev) - member
+  - [ ] [Kubernetes Dev](https://groups.google.com/a/kubernetes.io/g/dev) - member
 - [ ] Verify Discuss account
 - [ ] github.com/kubernetes-security membership
 - [ ] Slack


### PR DESCRIPTION
- Clarified language on announcement of medium/low CVEs with public fixes
- Updated the CVSS calculator from 3.1 to 3.0
- Added useful tips in comms. template for vulnerability announcement email
- Change kubernetes-dev to dev (at) kubernetes.io in onboarding checklist
- Fixed broken link for upgrading a cluster

/cc @cjcullen @tabbysable @tallclair @ritazh @enj 