### PR TITLE
update release roles links in security release process 

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -106,17 +106,12 @@ workflow](SRC-oncall.md).
 Included on the [private Release Managers list](https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers-private)
 are the following members:
 
-- [Release Managers](https://git.k8s.io/sig-release/release-managers.md#release-managers)
+- [Release Managers](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md#release-managers)
 (manage build and release aspects when a security fix must be delivered)
-- [SIG Release Chairs](https://git.k8s.io/sig-release/release-managers.md#sig-release-chairs)
+- [SIG Release Chairs](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md#chairs)
 
-It is the responsibility of the [SIG Release Chairs](https://git.k8s.io/sig-release/release-managers.md#sig-release-chairs)
+It is the responsibility of the [SIG Release Chairs](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md#chairs)
 to curate and maintain the various release role access controls across release cycles.
-
-The [Build Admins](https://git.k8s.io/sig-release/release-managers.md#build-admins)
-(Googlers with access to build/publish Kubernetes deb/rpm packages) are not
-explicitly part of the private security release team, but are also involved in
-delivery and must abide by the private disclosure process.
 
 ## Disclosures
 


### PR DESCRIPTION
-  meanwhile: remove build admins due to https://github.com/kubernetes/website/pull/43408