### PR TITLE
Add a canned response to clickjacking reports on kubernetes.io

### DIFF
--- a/comms-templates/clickjacking-response.md
+++ b/comms-templates/clickjacking-response.md
@@ -1,0 +1,7 @@
+Thank you for your interest in helping improve the security of Kubernetes.
+
+The public Kubernetes website is a read-only resource that does not collect or process any personal information, and as such, we do not believe that clickjacking is a threat to the project or its users. If you believe you have discovered a particular instance in which clickjacking can be used to harm a user or the project, please supply additional details.
+
+Thank you,
+
+The Kubernetes Security Response Committee


### PR DESCRIPTION
Reduce the effort of responding to reports of clickjacking as a vulnerability on kubernetes.io by documenting a response.