### PR TITLE
Create spf-record-response.md

### DIFF
--- a/comms-templates/spf-record-response.md
+++ b/comms-templates/spf-record-response.md
@@ -1,0 +1,7 @@
+Thank you for your interest in helping improve the security of Kubernetes.
+
+Kubernetes is an open-source project, and does not have customers or regularly send emails from the kubernetes.io domain. As such, we do not believe that the current configuration of our SPF record poses a threat to the project or its users. If you believe you have discovered a particular instance in which the configuration of our SPF record can be used to harm a specific user or the project, please supply additional details.
+
+Thank you,
+
+The Kubernetes Security Response Committee


### PR DESCRIPTION
Document a standard response to the commonly-received reports about the SPF record for kubernetes.io