### PR TITLE
Update slack onboarding/offboarding and slack vuln announcement template

### DIFF
--- a/comms-templates/vulnerability-announcement-slack.md
+++ b/comms-templates/vulnerability-announcement-slack.md
@@ -1,8 +1,6 @@
 _Use this slack message template for publicly disclosing security vulnerabilities on slack._
 
-_This message should be posted to the `#announcements` channel, which requires special permissions.
-Ask on `#slack-admins` for someone to grant you temporary posting permission, or to post the message
-on your behalf.`
+_This message should be posted to the `#announcements` channel, which requires special permissions._
 
 ---
 

--- a/src-onboarding-offboarding.md
+++ b/src-onboarding-offboarding.md
@@ -238,7 +238,11 @@ who is already a member of those channels:
 1. `#SRC-private` for private SRC-only discussion
 2. `#security-release-team` for private discussions with the security-release-team
 
-Members who are stepping down must leave the channels themselves.
+Members who are stepping down must leave the channels themselves. 
+
+Finally, ask a `#slack-admins` member to add the new SRC member to the list of people who can post in `#announcements`. 
+
+If a member is stepping down, we must let the admins know to remove the `#announcements` permission. 
 
 #### Calendar
 


### PR DESCRIPTION
SRC members now have permission to post directly in #announcements. We need to add this to part of our onboarding/offboarding to let the slack-admins know.